### PR TITLE
Fix for issue #32

### DIFF
--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -61,6 +61,8 @@ namespace TE.Plex
             this.lblCheckEveryLabel = new System.Windows.Forms.Label();
             this.numSeconds = new System.Windows.Forms.NumericUpDown();
             this.lblCheckSecondsLabel = new System.Windows.Forms.Label();
+            this.lblInProgressRecordingCount = new System.Windows.Forms.Label();
+            this.lblInProgressRecordingCountLabel = new System.Windows.Forms.Label();
             this.grpUpdateStatus.SuspendLayout();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numSeconds)).BeginInit();
@@ -68,7 +70,7 @@ namespace TE.Plex
             // 
             // btnCancel
             // 
-            this.btnCancel.Location = new System.Drawing.Point(476, 429);
+            this.btnCancel.Location = new System.Drawing.Point(476, 448);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 1;
@@ -79,7 +81,7 @@ namespace TE.Plex
             // 
             // btnUpdate
             // 
-            this.btnUpdate.Location = new System.Drawing.Point(394, 429);
+            this.btnUpdate.Location = new System.Drawing.Point(394, 448);
             this.btnUpdate.Name = "btnUpdate";
             this.btnUpdate.Size = new System.Drawing.Size(75, 23);
             this.btnUpdate.TabIndex = 2;
@@ -90,7 +92,7 @@ namespace TE.Plex
             // grpUpdateStatus
             // 
             this.grpUpdateStatus.Controls.Add(this.txtUpdateStatus);
-            this.grpUpdateStatus.Location = new System.Drawing.Point(12, 117);
+            this.grpUpdateStatus.Location = new System.Drawing.Point(12, 136);
             this.grpUpdateStatus.Name = "grpUpdateStatus";
             this.grpUpdateStatus.Size = new System.Drawing.Size(538, 289);
             this.grpUpdateStatus.TabIndex = 3;
@@ -108,6 +110,8 @@ namespace TE.Plex
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.lblInProgressRecordingCount);
+            this.groupBox1.Controls.Add(this.lblInProgressRecordingCountLabel);
             this.groupBox1.Controls.Add(this.lblPlayCount);
             this.groupBox1.Controls.Add(this.lblPlayCountLabel);
             this.groupBox1.Controls.Add(this.lblLatestVersion);
@@ -116,7 +120,7 @@ namespace TE.Plex
             this.groupBox1.Controls.Add(this.lblInstalledVersionLabel);
             this.groupBox1.Location = new System.Drawing.Point(13, 13);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(537, 98);
+            this.groupBox1.Size = new System.Drawing.Size(537, 116);
             this.groupBox1.TabIndex = 4;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Plex Media Server Information";
@@ -156,7 +160,7 @@ namespace TE.Plex
             // 
             // lblLatestVersionLabel
             // 
-            this.lblLatestVersionLabel.Location = new System.Drawing.Point(6, 43);
+            this.lblLatestVersionLabel.Location = new System.Drawing.Point(7, 43);
             this.lblLatestVersionLabel.Name = "lblLatestVersionLabel";
             this.lblLatestVersionLabel.Size = new System.Drawing.Size(100, 13);
             this.lblLatestVersionLabel.TabIndex = 1;
@@ -172,7 +176,7 @@ namespace TE.Plex
             // 
             // btnExit
             // 
-            this.btnExit.Location = new System.Drawing.Point(475, 429);
+            this.btnExit.Location = new System.Drawing.Point(475, 448);
             this.btnExit.Name = "btnExit";
             this.btnExit.Size = new System.Drawing.Size(75, 23);
             this.btnExit.TabIndex = 5;
@@ -185,7 +189,7 @@ namespace TE.Plex
             this.chkWait.AutoSize = true;
             this.chkWait.Checked = true;
             this.chkWait.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkWait.Location = new System.Drawing.Point(19, 412);
+            this.chkWait.Location = new System.Drawing.Point(19, 431);
             this.chkWait.Name = "chkWait";
             this.chkWait.Size = new System.Drawing.Size(161, 17);
             this.chkWait.TabIndex = 6;
@@ -196,7 +200,7 @@ namespace TE.Plex
             // lblCheckEveryLabel
             // 
             this.lblCheckEveryLabel.AutoSize = true;
-            this.lblCheckEveryLabel.Location = new System.Drawing.Point(16, 439);
+            this.lblCheckEveryLabel.Location = new System.Drawing.Point(16, 458);
             this.lblCheckEveryLabel.Name = "lblCheckEveryLabel";
             this.lblCheckEveryLabel.Size = new System.Drawing.Size(67, 13);
             this.lblCheckEveryLabel.TabIndex = 7;
@@ -204,7 +208,7 @@ namespace TE.Plex
             // 
             // numSeconds
             // 
-            this.numSeconds.Location = new System.Drawing.Point(89, 437);
+            this.numSeconds.Location = new System.Drawing.Point(89, 456);
             this.numSeconds.Maximum = new decimal(new int[] {
             3600,
             0,
@@ -227,17 +231,34 @@ namespace TE.Plex
             // lblCheckSecondsLabel
             // 
             this.lblCheckSecondsLabel.AutoSize = true;
-            this.lblCheckSecondsLabel.Location = new System.Drawing.Point(148, 439);
+            this.lblCheckSecondsLabel.Location = new System.Drawing.Point(148, 458);
             this.lblCheckSecondsLabel.Name = "lblCheckSecondsLabel";
             this.lblCheckSecondsLabel.Size = new System.Drawing.Size(47, 13);
             this.lblCheckSecondsLabel.TabIndex = 9;
             this.lblCheckSecondsLabel.Text = "seconds";
             // 
+            // lblInProgressRecordingCount
+            // 
+            this.lblInProgressRecordingCount.Location = new System.Drawing.Point(178, 89);
+            this.lblInProgressRecordingCount.Name = "lblInProgressRecordingCount";
+            this.lblInProgressRecordingCount.Size = new System.Drawing.Size(100, 17);
+            this.lblInProgressRecordingCount.TabIndex = 9;
+            this.lblInProgressRecordingCount.Text = "[]";
+            // 
+            // lblInProgressRecordingCountLabel
+            // 
+            this.lblInProgressRecordingCountLabel.AutoSize = true;
+            this.lblInProgressRecordingCountLabel.Location = new System.Drawing.Point(7, 89);
+            this.lblInProgressRecordingCountLabel.Name = "lblInProgressRecordingCountLabel";
+            this.lblInProgressRecordingCountLabel.Size = new System.Drawing.Size(165, 13);
+            this.lblInProgressRecordingCountLabel.TabIndex = 8;
+            this.lblInProgressRecordingCountLabel.Text = "Number of in progress recordings:";
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(563, 472);
+            this.ClientSize = new System.Drawing.Size(563, 490);
             this.Controls.Add(this.lblCheckSecondsLabel);
             this.Controls.Add(this.numSeconds);
             this.Controls.Add(this.lblCheckEveryLabel);
@@ -272,5 +293,7 @@ namespace TE.Plex
         private System.Windows.Forms.Label lblCheckEveryLabel;
         private System.Windows.Forms.NumericUpDown numSeconds;
         private System.Windows.Forms.Label lblCheckSecondsLabel;
+        private System.Windows.Forms.Label lblInProgressRecordingCount;
+        private System.Windows.Forms.Label lblInProgressRecordingCountLabel;
     }
 }

--- a/TE.Plex/classes/Api.cs
+++ b/TE.Plex/classes/Api.cs
@@ -6,10 +6,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
+using System.Xml.Linq;
 using System.Xml.Serialization;
 
 namespace TE.Plex
-{ 
+{
     public class Api
     {
         #region Event Delegates
@@ -143,7 +144,7 @@ namespace TE.Plex
 
             using (StringReader sr = new StringReader(content))
             {
-                XmlSerializer serializer = 
+                XmlSerializer serializer =
                     new XmlSerializer(typeof(MediaContainer));
                 try
                 {
@@ -160,6 +161,79 @@ namespace TE.Plex
             }
 
             return playCount;
+        }
+
+        /// <summary>
+        /// Gets the number of in progress recordings (i.e. by the DVR) on the Plex server.
+        /// </summary>
+        /// /// <returns>
+        /// The number of items being currently recorded.
+        /// </returns>
+        public int GetInProgressRecordingCount()
+        {
+            int inProgressRecordingCount = Unknown;
+            if (string.IsNullOrWhiteSpace(_server))
+            {
+                OnMessageChanged("The Plex server was not provided so the in progress recording count could not be retrieved.");
+                return inProgressRecordingCount;
+            }
+
+            if (string.IsNullOrWhiteSpace(_token))
+            {
+                OnMessageChanged("The Plex token was not provided so the in progress recording count could not be retrieved.");
+                return inProgressRecordingCount;
+            }
+
+            string url = $"http://{_server}:32400/media/subscriptions/scheduled?X-Plex-Token={_token}";
+            string content = null;
+            try
+            {
+                using (HttpResponseMessage response = _client.GetAsync(url).Result)
+                {
+                    if (response.StatusCode == System.Net.HttpStatusCode.OK)
+                    {
+                        content = response.Content.ReadAsStringAsync().Result;
+                    }
+                    else
+                    {
+                        OnMessageChanged($"The connection to the Plex server wasn't successful. Status: {response.StatusCode.ToString()}.");
+                    }
+                }
+            }
+            catch (Exception ex)
+                when (ex is ArgumentNullException || ex is HttpRequestException)
+            {
+                OnMessageChanged($"There was an issue sending the request to the Plex server. Reason: {ex.Message}");
+                return inProgressRecordingCount;
+            }
+            catch (AggregateException ae)
+            {
+                foreach (var e in ae.Flatten().InnerExceptions)
+                {
+                    OnMessageChanged($"Could not process the response result. Message: {e.Message}.");
+                }
+                return inProgressRecordingCount;
+            }
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                OnMessageChanged("No content was returned from the Plex server.");
+                return inProgressRecordingCount;
+            }
+
+            try
+            {
+                var xml = XDocument.Parse(content);
+                inProgressRecordingCount = xml.Descendants("MediaGrabOperation").Count(x => (string)x.Attribute("status") == "inprogress");
+            }
+            catch (Exception ex)
+                when (ex is XmlException)
+            {
+                OnMessageChanged($"The content could not be parsed. Reason: {ex.Message}");
+                return inProgressRecordingCount;
+            }
+
+            return inProgressRecordingCount;
         }
         #endregion
     }


### PR DESCRIPTION
Added code related to issue #32 to check if there are any in progress recordings.  See commit comments, but it should be noted that since we can't currently kill the DVR process I short-circuit the ability to **force** update the server if there is an in progress recording.

Also took care of a couple of trivial textual bugs.