### PR TITLE
Config Settings For Plex Service Names

### DIFF
--- a/Plex/MediaServer.cs
+++ b/Plex/MediaServer.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Win32;
 using Msi = TE.LocalSystem.Msi;
 using TE.Plex.Update;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Security;
-using System.Configuration;
 
 namespace TE.Plex
 {
@@ -95,31 +96,31 @@ namespace TE.Plex
         /// <summary>
         /// The DisplayName of the Plex Media Server installation.
         /// </summary>
-        private static string DisplayName = ConfigurationManager.AppSettings["PlexServiceName"];
+        private const string DisplayName = "Plex Media Server";
         /// <summary>
         /// The name of the Plex Media Server executable.
         /// </summary>
-        private static string PlexExecutable = ConfigurationManager.AppSettings["PlexExecutable"];
+        private const string PlexExecutable = "Plex Media Server.exe";
         /// <summary>
         /// The name of the Plex updates folder.
         /// </summary>
-        private static string PlexUpdatesFolder = ConfigurationManager.AppSettings["PlexUpdatesFolder"];
+        private const string PlexUpdatesFolder = @"Plex Media Server\Updates";
         /// <summary>
         /// The name of the installation packages folder.
         /// </summary>
-        private static string PlexPackagesFolder = ConfigurationManager.AppSettings["PlexPackagesFolder"];
+        private const string PlexPackagesFolder = "packages";
         /// <summary>
         /// Plex Media Server installation parameters.
         /// </summary>
-        private static string PlexInstallParameters = ConfigurationManager.AppSettings["PlexInstallParameters"];
+        private const string PlexInstallParameters = "/install /quiet /norestart /log ";
         /// <summary>
         /// Plex Media Server installation log subfolder.
         /// </summary>
-        private static string PlexInstallLogFolder = ConfigurationManager.AppSettings["PlexInstallLogFolder"];
+        private const string PlexInstallLogFolder = @"PlexUpdater";
         /// <summary>
         /// Plex Media Server installation log file name.
         /// </summary>
-        private static string PlexInstallLogFile = ConfigurationManager.AppSettings["PlexInstallLogFile"];
+        private const string PlexInstallLogFile = "PlexMediaServerInstall.log";
         /// <summary>
         /// Maxiumum path length.
         /// </summary>

--- a/Plex/MediaServer.cs
+++ b/Plex/MediaServer.cs
@@ -3,13 +3,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
-using Microsoft.Win32;
 using Msi = TE.LocalSystem.Msi;
 using TE.Plex.Update;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Security;
+using System.Configuration;
 
 namespace TE.Plex
 {
@@ -96,31 +95,31 @@ namespace TE.Plex
         /// <summary>
         /// The DisplayName of the Plex Media Server installation.
         /// </summary>
-        private const string DisplayName = "Plex Media Server";
+        private static string DisplayName = ConfigurationManager.AppSettings["PlexServiceName"];
         /// <summary>
         /// The name of the Plex Media Server executable.
         /// </summary>
-        private const string PlexExecutable = "Plex Media Server.exe";
+        private static string PlexExecutable = ConfigurationManager.AppSettings["PlexExecutable"];
         /// <summary>
         /// The name of the Plex updates folder.
         /// </summary>
-        private const string PlexUpdatesFolder = @"Plex Media Server\Updates";
+        private static string PlexUpdatesFolder = ConfigurationManager.AppSettings["PlexUpdatesFolder"];
         /// <summary>
         /// The name of the installation packages folder.
         /// </summary>
-        private const string PlexPackagesFolder = "packages";
+        private static string PlexPackagesFolder = ConfigurationManager.AppSettings["PlexPackagesFolder"];
         /// <summary>
         /// Plex Media Server installation parameters.
         /// </summary>
-        private const string PlexInstallParameters = "/install /quiet /norestart /log ";
+        private static string PlexInstallParameters = ConfigurationManager.AppSettings["PlexInstallParameters"];
         /// <summary>
         /// Plex Media Server installation log subfolder.
         /// </summary>
-        private const string PlexInstallLogFolder = @"PlexUpdater";
+        private static string PlexInstallLogFolder = ConfigurationManager.AppSettings["PlexInstallLogFolder"];
         /// <summary>
         /// Plex Media Server installation log file name.
         /// </summary>
-        private const string PlexInstallLogFile = "PlexMediaServerInstall.log";
+        private static string PlexInstallLogFile = ConfigurationManager.AppSettings["PlexInstallLogFile"];
         /// <summary>
         /// Maxiumum path length.
         /// </summary>

--- a/Plex/ServerService.cs
+++ b/Plex/ServerService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Management;
 using System.ServiceProcess;
 using TE.LocalSystem;
-using System.Configuration;
 
 namespace TE.Plex
 {
@@ -18,7 +17,7 @@ namespace TE.Plex
         /// <summary>
         /// The name of the Plex service.
         /// </summary>
-        private static string ServiceName = ConfigurationManager.AppSettings["PlexServiceName"];
+        private const string ServiceName = "PlexService";
         #endregion
 
         #region Properties

--- a/Plex/ServerService.cs
+++ b/Plex/ServerService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Management;
 using System.ServiceProcess;
 using TE.LocalSystem;
+using System.Configuration;
 
 namespace TE.Plex
 {
@@ -17,7 +18,7 @@ namespace TE.Plex
         /// <summary>
         /// The name of the Plex service.
         /// </summary>
-        private const string ServiceName = "PlexService";
+        private static string ServiceName = ConfigurationManager.AppSettings["PlexServiceName"];
         #endregion
 
         #region Properties

--- a/PlexServerAutoUpdater.csproj
+++ b/PlexServerAutoUpdater.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>TE</RootNamespace>
     <AssemblyName>psupdate</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <NoWin32Manifest>False</NoWin32Manifest>
     <SignAssembly>False</SignAssembly>
@@ -58,7 +58,6 @@
       <HintPath>..\..\Visual Studio 2017\Projects\Supporting\Newtonsoft.Json\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>

--- a/PlexServerAutoUpdater.csproj
+++ b/PlexServerAutoUpdater.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>TE</RootNamespace>
     <AssemblyName>psupdate</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <NoWin32Manifest>False</NoWin32Manifest>
     <SignAssembly>False</SignAssembly>
@@ -58,6 +58,7 @@
       <HintPath>..\..\Visual Studio 2017\Projects\Supporting\Newtonsoft.Json\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>

--- a/app.config
+++ b/app.config
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<startup>
-		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
 	</startup>
+  <appSettings>
+    <add key="PlexServiceName" value="PlexMediaServer"/>
+    <add key="PlexExecutable" value="Plex Media Server.exe"/>
+    <add key="PlexUpdatesFolder" value="Plex Media Server\Updates"/>
+    <add key="PlexPackagesFolder" value="packages"/>
+    <add key="PlexInstallParameters" value="/install /quiet /norestart /log "/>
+    <add key="PlexInstallLogFolder" value="PlexUpdater"/>
+    <add key="PlexInstallLogFile" value="PlexMediaServerInstall.log"/>
+  </appSettings>
 </configuration>

--- a/app.config
+++ b/app.config
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<startup>
-		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
 	</startup>
-  <appSettings>
-    <add key="PlexServiceName" value="PlexMediaServer"/>
-    <add key="PlexExecutable" value="Plex Media Server.exe"/>
-    <add key="PlexUpdatesFolder" value="Plex Media Server\Updates"/>
-    <add key="PlexPackagesFolder" value="packages"/>
-    <add key="PlexInstallParameters" value="/install /quiet /norestart /log "/>
-    <add key="PlexInstallLogFolder" value="PlexUpdater"/>
-    <add key="PlexInstallLogFile" value="PlexMediaServerInstall.log"/>
-  </appSettings>
 </configuration>


### PR DESCRIPTION
Tried to use your program, but my Plex service was installed with a different name and it would not work.  Changed hardcoded values to app config keys so that they could be adjusted easily.  Feel free to ignore this pull request.