### PR TITLE
Installation not found fix

### DIFF
--- a/Plex/MediaServer.cs
+++ b/Plex/MediaServer.cs
@@ -418,6 +418,16 @@ namespace TE.Plex
                 }
             }
 
+            // If the standard install paths were not in use, then try and get
+            // the installation path from the Plex registry key
+            if (string.IsNullOrWhiteSpace(installPath))
+            {
+                if (plexRegistry != null)
+                {
+                    installPath = plexRegistry.GetInstallFolder();
+                }
+            }
+
             // If the install path does not contain a value, then if the Plex
             // Media Server is running, let's try and get the path from the
             // process
@@ -520,14 +530,6 @@ namespace TE.Plex
                     "The Plex Media Server is not installed.");
             }
 
-            InstallFolder = GetInstallPath();
-            if (string.IsNullOrWhiteSpace(InstallFolder))
-            {
-                throw new AppNotInstalledException(
-                    "Plex does not appear to be installed as the Plex installation folder could not be determined.");
-            }
-            OnMessageChanged($"Plex install folder: {InstallFolder}.");
-
             // Populate a service object with information about the Plex
             // service
             plexService = new ServerService();
@@ -538,6 +540,14 @@ namespace TE.Plex
             }
 
             plexRegistry = new Registry(plexService.LogOnUser);
+
+            InstallFolder = GetInstallPath();
+            if (string.IsNullOrWhiteSpace(InstallFolder))
+            {
+                throw new AppNotInstalledException(
+                    "Plex does not appear to be installed as the Plex installation folder could not be determined.");
+            }
+            OnMessageChanged($"Plex install folder: {InstallFolder}.");
 
             // Get the Plex folders
             LocalDataFolder = plexRegistry.GetLocalDataFolder();

--- a/Plex/MediaServer.cs
+++ b/Plex/MediaServer.cs
@@ -142,6 +142,10 @@ namespace TE.Plex
         /// </summary>
         private static string PlexInstallLogFile = ConfigurationManager.AppSettings["PlexInstallLogFile"];
         /// <summary>
+        /// Plex Media Server installation log file name.
+        /// </summary>
+        private static string PlexInstallLocation = ConfigurationManager.AppSettings["PlexInstallLocation"];
+        /// <summary>
         /// The root Plex installation folder.
         /// </summary>
         private static string PlexFolder = "Plex";
@@ -393,28 +397,38 @@ namespace TE.Plex
         {
             string installPath = null;
 
-            // To avoid using the Windows Installer API, let's first check well
-            // known paths to find the Plex install location
-            List<string> defaultLocations = new List<string>();
-            string programFilesX86 = Environment.ExpandEnvironmentVariables("%ProgramFiles(x86)%");
-            if (!string.IsNullOrWhiteSpace(programFilesX86))
+            // If the install location was specified in the config file, then
+            // use that value
+            if (!string.IsNullOrWhiteSpace(PlexInstallLocation))
             {
-                defaultLocations.Add(Path.Combine(programFilesX86, PlexFolder, PlexSubFolder));
-            }
-            
-            string programFiles = Environment.ExpandEnvironmentVariables("%ProgramW6432%");
-            if (!string.IsNullOrWhiteSpace(programFiles))
-            {
-                defaultLocations.Add(Path.Combine(programFiles, PlexFolder, PlexSubFolder));
+                installPath = PlexInstallLocation;
             }
 
-            foreach (string location in defaultLocations)
+            if (string.IsNullOrWhiteSpace(installPath))
             {
-                string path = Path.Combine(location, PlexExecutable);
-                if (File.Exists(path))
+                // To avoid using the Windows Installer API, let's first check well
+                // known paths to find the Plex install location
+                List<string> defaultLocations = new List<string>();
+                string programFilesX86 = Environment.ExpandEnvironmentVariables("%ProgramFiles(x86)%");
+                if (!string.IsNullOrWhiteSpace(programFilesX86))
                 {
-                    installPath = Path.GetDirectoryName(path);
-                    break;
+                    defaultLocations.Add(Path.Combine(programFilesX86, PlexFolder, PlexSubFolder));
+                }
+
+                string programFiles = Environment.ExpandEnvironmentVariables("%ProgramW6432%");
+                if (!string.IsNullOrWhiteSpace(programFiles))
+                {
+                    defaultLocations.Add(Path.Combine(programFiles, PlexFolder, PlexSubFolder));
+                }
+
+                foreach (string location in defaultLocations)
+                {
+                    string path = Path.Combine(location, PlexExecutable);
+                    if (File.Exists(path))
+                    {
+                        installPath = Path.GetDirectoryName(path);
+                        break;
+                    }
                 }
             }
 

--- a/Plex/Registry.cs
+++ b/Plex/Registry.cs
@@ -39,6 +39,11 @@ namespace TE.Plex
         private const string RegistryPlexDataPathValueName = "LocalAppDataPath";
 
         /// <summary>
+        /// The location of the Plex installation.
+        /// </summary>
+        private const string RegistryInstallFolder = "InstallFolder";
+
+        /// <summary>
         /// The user running the Plex server application.
         /// </summary>
         private WindowsUser user;
@@ -148,6 +153,27 @@ namespace TE.Plex
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Gets the location of the Plex installation folder.
+        /// </summary>
+        /// <returns>
+        /// The location of the Plex installation folder, otherwise <c>null</c>.
+        /// </returns>
+        internal string GetInstallFolder()
+        {
+            try
+            {
+                // Get the Plex local data folder from the users registry hive
+                // for the user ID associated with the Plex service
+                return (string)GetValue(RegistryInstallFolder);
+            }
+            catch (Exception ex)
+                when (ex is ArgumentNullException || ex is ObjectDisposedException || ex is SecurityException || ex is IOException || ex is UnauthorizedAccessException)
+            {
+                return null;
+            }
         }
 
         /// <summary>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can use the default the Revision and 
 // Build Numbers by using the '*' as shown below:
-[assembly: AssemblyVersion("0.2.1.0")]
-[assembly: AssemblyFileVersion("0.2.1.0")]
+[assembly: AssemblyVersion("0.2.1.1")]
+[assembly: AssemblyFileVersion("0.2.1.1")]
 


### PR DESCRIPTION
* Added `PlexInstallLocation` key option to the configuration file so the full path to the Plex installation can be specified.